### PR TITLE
Add initial design docs for common components

### DIFF
--- a/docs/design/ctrv_model.md
+++ b/docs/design/ctrv_model.md
@@ -1,0 +1,41 @@
+# Constant turn-rate and velocity (CTRV) model
+
+## `CtrvState`
+
+This class contains the state variables used for the constant turn-rate and velocity (CTRV) motion model.
+
+### Possible implementation
+
+```cpp
+using CtrvState = Eigen::Matrix<float, 5, 1>;
+```
+
+
+## `CtrvCovariance`
+
+This class contains the covariance matrix for the state vector used in the CTRV motion model.
+
+### Possible implementation
+
+```cpp
+using CtrvCovariance = Eigen::Matrix<float, 5, 5>;
+```
+
+## Calculate next CTRV state
+
+### Interface
+```cpp
+auto nextState(
+    const cooperative_perception::CtrvState& state,
+    const cooperative_perception::CtrvStateCovariance& covariance,
+    float time_step
+) -> std::tuple<cooperative_perception::CtrvState, cooperative_perception::CtrvStateCovariance>;
+```
+
+### Parameters
+* `state`: current system state
+* `covariance`: current system covariance
+* `time_step`: state propagation duration
+
+### Returns
+* `std::tuple` containing the new `CtrvState` and `CtrvStateCovariance`

--- a/docs/design/key_classes.md
+++ b/docs/design/key_classes.md
@@ -1,0 +1,55 @@
+# Key classes
+
+## `DetectedObject`
+
+This class represents a detected object received from the host agent (HA) or a remote agent (RA).
+
+### Member variables
+
+* `timestamp`: global time associated with the `state`
+* `state`: state vector (CTRV model)
+* `state_covariance`: covariance matrix associated with `state`
+
+### Possible implementation
+
+```cpp
+struct {
+    namespace cp = cooperative_perception;
+
+    std::chrono::time_point timestamp;
+    cp::CtrvState state;
+    cp::CtrvStateCovariance covariance;
+};
+```
+
+## `DetectedObjectList`
+
+This class contains a list of `DetectedObject`s. We use a custom type instead of directly using a container type (e.g., `std::vector`) because we have size constraints to ensure timing requirements are met.
+
+### Possible implementation
+
+```cpp
+using DetectedObjectList = boost::container::static_vector<DetectedObject, 200>;
+```
+
+## `RemoteAgent`
+
+This class represents a remote agent that shares its own state and detected objects.
+
+### Member variables
+
+* `timestamp`: global time associated with the `state`
+* `state`: state vector (CTRV model)
+* `state_covariance`: covariance matrix associated with `state`
+
+### Possible implementation
+
+```cpp
+struct {
+    namespace cp = cooperative_perception;
+
+    std::chrono::time_point timestamp;
+    cp::CtrvState state;
+    cp::CtrvStateCovariance covariance;
+};
+```


### PR DESCRIPTION
<!-- Thanks for the contribution, this is awesome. -->

# PR Details
## Description

<!--- Describe your changes in detail -->

This PR adds some initial documentation for the CTRV motion model that will be used for detected object tracking . It also adds descriptions for objects common the the entire code base.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

We need good documentation.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [ ] Defect fix (non-breaking change that fixes an issue)
- [ ] New feature (non-breaking change that adds functionality)
- [ ] Breaking change (fix or feature that cause existing functionality to change)
- [x] Additional documentation

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have added any new packages to the sonar-scanner.properties file
- [ ] My change requires a change to the documentation.
- [x] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
[CARMA Contributing Guide](https://github.com/usdot-fhwa-stol/carma-platform/blob/develop/Contributing.md)
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
